### PR TITLE
Package Version and Gitlab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,28 @@
+---
+variables:
+  PYTHON_IMAGE_TAG: 3.9.7
+stages:
+  - build
+  - deploy
+
+build_package:
+  stage: build
+  image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/python:$PYTHON_IMAGE_TAG
+  artifacts:
+    paths:
+      - dist
+  script:
+    - curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python3 -
+    - export PATH=$HOME/.local/bin:$PATH
+    - poetry build
+
+deploy_package:
+  stage: deploy
+  image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/python:$PYTHON_IMAGE_TAG
+  rules:
+    - if: '$CI_COMMIT_TAG =~ /^v\d+\.\d+\.\d+$/'
+  script:
+    - curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python3 -
+    - export PATH=$HOME/.local/bin:$PATH
+    - poetry config repositories.privatepypi ${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/pypi
+    - poetry publish --repository privatepypi --username gitlab-ci-token --password ${CI_JOB_TOKEN}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "target-athena"
-version = "0.0.1"
+version = "1.4.1"
 description = "`target-athena` is Singer tap for Athena, built with the Singer SDK."
 authors = ["FirstName LastName"]
 license = "Apache 2.0"


### PR DESCRIPTION
## Problem

Packages are not created with the version for the Python module set.  There is no automation to build and deploy the package to any type of registry.

## Proposed changes

Set the version in the pyproject.toml file to 1.4.1, then set a tag to match.  Without this, there is no way to specify a specific version of the module (all builds are set to version 0.0.1), which will pose issues for future breaking changes.

Add .gitlab-ci.yml file for Gitlab CI.  This is a generic CI that should work with any recent Gitlab server with the Package Registry.  It also uses the Dependency Proxy in the CI to pull the docker image for Python to avoid issues with Docker Hub's rate limiting.  This requires the Dependency Proxy setup on the Gitlab server also.  Note, however, that the .gitlab.yml file is non-functional on a Github server, and will only take effect if the project is pushed to a Gitlab server.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions