### PR TITLE
set jsonl explicitly to case insensitive

### DIFF
--- a/target_athena/sinks.py
+++ b/target_athena/sinks.py
@@ -140,7 +140,7 @@ class AthenaSink(BatchSink):
                 data_location=data_location,
                 skip_header=False,
                 row_format="org.openx.data.jsonserde.JsonSerDe",
-                serdeproperties="'ignore.malformed.json'='true', 'case.insensitive'='false'"
+                serdeproperties="'ignore.malformed.json'='true', 'case.insensitive'='true'"
             )
         else:
             self.logger.warn(f"Unrecognized format: '{object_format}'")


### PR DESCRIPTION
I thought that I fixed this in https://github.com/MeltanoLabs/target-athena/pull/30 but it looks like I missed the kwarg input so the default wasnt being used for jsonl still. After this is in I can swap back to using this in the [squared project](https://gitlab.com/meltano/squared/-/blob/master/data/meltano.yml#L99).

## Problem

Default to case insensitive for jsonl records.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)