### PR TITLE
fix: Supply session token while connecting to Athena

### DIFF
--- a/target_athena/athena.py
+++ b/target_athena/athena.py
@@ -40,6 +40,7 @@ def create_client(config, logger: Logger):
         cursor = connect(
             aws_access_key_id=aws_access_key_id,
             aws_secret_access_key=aws_secret_access_key,
+            aws_session_token=aws_session_token,
             region_name=aws_region,
             s3_staging_dir=s3_staging_dir,
             work_group=athena_workgroup,

--- a/tests/integration/test_target_athena.py
+++ b/tests/integration/test_target_athena.py
@@ -77,10 +77,12 @@ class TestIntegration(unittest.TestCase):
             # Move aws access key and secret from config into environment variables
             os.environ['AWS_ACCESS_KEY_ID'] = os.environ.get('TARGET_ATHENA_ACCESS_KEY_ID')
             os.environ['AWS_SECRET_ACCESS_KEY'] = os.environ.get('TARGET_ATHENA_SECRET_ACCESS_KEY')
+            os.environ['AWS_SESSION_TOKEN'] = os.environ.get('TARGET_ATHENA_SESSION_TOKEN')
 
             config_aws_env_vars = self.config.copy()
             config_aws_env_vars['aws_access_key_id'] = None
             config_aws_env_vars['aws_secret_access_key'] = None
+            config_aws_env_vars['aws_session_token'] = None
 
             # Create a new S3 client using env vars
             self.persist_messages(tap_lines)
@@ -89,6 +91,7 @@ class TestIntegration(unittest.TestCase):
         finally:
             del os.environ['AWS_ACCESS_KEY_ID']
             del os.environ['AWS_SECRET_ACCESS_KEY']
+            del os.environ['AWS_SESSION_TOKEN']
 
     def test_profile_based_auth(self):
         """Test AWS profile based authentication rather than access keys"""


### PR DESCRIPTION
## Problem

While connecting to Athena the AWS Session token is not used

## Proposed changes

Supply the token while creating the pyathena cursor. 

## Related Issues

closes: https://github.com/MeltanoLabs/target-athena/issues/46

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions